### PR TITLE
Make compatible with latest requirements.

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,15 +1,15 @@
 ---
 # Configuration for the single Slack workspace
 slack:
-  # The bot's own username
+  # The bot's own username. Lowercase.
   username: shell
   # Bot token, used for most operations
-  # Configure this token to have channel:write scope.
+  # Make sure this is a legacy bot token (with scope bot).
   token: xoxb-your-token
-  # User token, used for creating DM bridge channels. Use your legacy custom token, not the bot's OAuth token.
-  user_token: xoxp-your-token
+  # User token, used for creating DM bridge channels. Use your auth.signin token, not the bot's OAuth token.
+  user_token: xoxs-your-token
   # A token for a donor workspace used to provide avatars.
-  avatar_pilfering_token: xoxp-your-token
+  avatar_pilfering_token: xoxs-your-token
   # Channel to write error messages to
   errors: '#errors'
   # The puu.sh-compatible file host for mirroring uploads to

--- a/kari.py
+++ b/kari.py
@@ -437,7 +437,6 @@ class Kari:
             timeout=UPLOAD_REQUEST_TIMEOUT,
         ).json()
 
-        irc_conn.privmsg(irc_channel, resp['share_url'])
         self.slack_api(
             "chat.postMessage",
             {
@@ -690,7 +689,7 @@ def delink(match):
 
 
 def emojize(msg):
-    return emoji.emojize(msg, use_aliases=True)
+    return emoji.emojize(msg, language='alias')
 
 
 def reformat_slack(msg):


### PR DESCRIPTION
Some small changes were needed to successfully configure kari with the latest versions of all requirements:
- `use_aliases` was removed in emoji 2.0.0: https://github.com/carpedm20/emoji/blob/master/CHANGES.md#v200-2022-06-30
- It appears the Slack message events are triggered even for same-bot messages, so it's no longer necessary to separately send the mirrored file URL to IRC.

Some changes took place "in the real world":
- Slack doesn't allow you to make legacy tokens anymore, so I updated the docs to reflect where I got a working token.
- "New" Slack apps don't allow you to use `rtm.connect`, but you can still add a legacy bot to your workspace and use that token.
- PEBCAK error caused by not realizing that usernames need to be lowercase.