### PR TITLE
Migrate from legacy bots to Slack App API using Socket Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+__pycache__
 /venv/
 config.yaml

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,11 +3,14 @@
 slack:
   # The bot's own username. Lowercase.
   username: shell
+  # Your Slack username, will be invited to DM bridge channels
+  realuser_username: kari
   # Bot token, used for most operations
-  # Make sure this is a legacy bot token (with scope bot).
+  # Get this token by installing your created app to your workspace.
   token: xoxb-your-token
-  # User token, used for creating DM bridge channels. Use your auth.signin token, not the bot's OAuth token.
-  user_token: xoxs-your-token
+  # App level token, used for apps.connections.open
+  # Enable Socket Mode in the app settings and configure this token to have connections:write scope.
+  websocket_token: xapp-your-token
   # A token for a donor workspace used to provide avatars.
   avatar_pilfering_token: xoxs-your-token
   # Channel to write error messages to

--- a/manifest.example.yaml
+++ b/manifest.example.yaml
@@ -1,0 +1,25 @@
+---
+# Sample Slack App manifest with proper list of scopes
+oauth_config:
+  scopes:
+    bot:
+      - channels:history
+      - channels:join
+      - channels:manage
+      - channels:read
+      - channels:write.invites
+      - channels:write.topic
+      - chat:write
+      - chat:write.customize
+      - users:read
+      - users:write
+settings:
+  event_subscriptions:
+    bot_events:
+      - channel_created
+      - message.channels
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false


### PR DESCRIPTION
- Instead of using the user token to create DM channels, uses Slack APIs in bot context to create and configure DM channels before inviting the user into the channel.
- Socket Mode requires a different type of token...
- Socket Mode Events API messages are encapsulated slightly differently than RTM, and require acks.
- Added an app manifest that I think includes all the relevant scopes.