### PR TITLE
Fix file upload mirroring 

### DIFF
--- a/kari.py
+++ b/kari.py
@@ -511,7 +511,7 @@ class Kari:
                 irc_conn = bridge.irc_channel.server.conn
                 irc_channel_name = bridge.irc_channel.name
 
-            if subtype in ('message_replied', 'thread_broadcast', None):
+            if subtype in ('message_replied', 'thread_broadcast', 'file_share', None):
                 # Normal message
 
                 # TODO: For non-broadcast replies, fetch the other replies from Slack, they aren't sent with this message any more
@@ -528,7 +528,8 @@ class Kari:
 
                 # Slack only provides 'root' for a thread broadcast message and
                 # provides nothing for message replies, so that sucks.
-                if 'root' in msg:
+                # Also, don't quotepost for the specific case of the internal pshuu mirror.
+                if 'root' in msg and msg.get('username') != 'pshuu_mirror':
                     root = msg['root']
                     if 'type' in root and root['type'] == 'message':
                         quoting_format = get_quoting_format(root.get('subtype'))

--- a/manifest.example.yaml
+++ b/manifest.example.yaml
@@ -11,6 +11,7 @@ oauth_config:
       - channels:write.topic
       - chat:write
       - chat:write.customize
+      - files:read
       - users:read
       - users:write
 settings:


### PR DESCRIPTION
This was broken because now files are usually shared into channels instead of being attached to a message. Also, it was broken because the new Slack app was missing the `files:read` OAuth scope. On the plus side, the OAuth app can be reinstalled with the proper scope without invalidating the existing token.

Also, since thread replies automatically quote-post, it was sending into IRC strangely:
```
<foobar2000> haha a file
<foobar2000> <slack_username> haha a file
<foobar2000> [uploaded url]
```

The hack to `if 'root' in msg` fixes this.